### PR TITLE
Very simple deployment script

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -1,0 +1,32 @@
+<?php
+namespace Deployer;
+
+require 'recipe/cakephp.php';
+
+// Configuration
+set('repository', 'https://github.com/Dallas-Makerspace/calendar.git');
+set('git_tty', true); // [Optional] Allocate tty for git on first deployment
+add('shared_files', []);
+add('shared_dirs', [
+    'protected'
+]);
+add('writable_dirs', [
+    'protected'
+]);
+set('allow_anonymous_stats', false);
+
+// Hosts
+
+host('calendar.dallasmakerspace.org')
+    ->stage('prod')
+    ->set('deploy_path', '/srv/http/calendar.dallasmakerspace.org');
+
+
+// Tasks
+task('deploy:executable', 'chmod +x bin/cake');
+
+before('deploy:init', 'deploy:executable');
+
+
+// [Optional] if deploy fails automatically unlock.
+after('deploy:failed', 'deploy:unlock');


### PR DESCRIPTION
Deployer is basically a simple shell wrapper for deploying to remote servers. Our current deployment process is unknown, but the `/var/www` webroot is cluttered with files. This solution does the following:

1. Ensures developers with server access can easily deploy their changes, and roll them back if they break.
2. Moves the deploy path to a new `/srv/http` directory, we can use `/var/www` if needed but there will be downtime as we switch. `/srv/http` will incur no downtime.
3. Keep `protected` files through deployment.
4. No crazy deployment configuration, just simple PHP.

In my mind this is a temporary solution to a more engineered solution, however we use this at my work and it works excellent.