### PR TITLE
BUGFIX Set RSS feed pubDate to the creation date of the event

### DIFF
--- a/src/Controller/EventsController.php
+++ b/src/Controller/EventsController.php
@@ -317,8 +317,7 @@ class EventsController extends AppController
                 $feed_event = $feed->newItem();
                 $feed_event->setTitle($event->name);
                 $feed_event->setLink($url);
-                //$feed_event->setLastModified(new \DateTime($event->modified));
-                $feed_event->setLastModified(new \DateTime($event->event_start));
+                $feed_event->setLastModified(new \DateTime($event->created));
                 $feed_event->setDescription($desc_html);
                 $feed_event->setPublicId($url, false);
 


### PR DESCRIPTION
RSS readers were having issues with pubDates that were in the future,
and if we didn't set lastModified/pubDate the library just uses now().