### PR TITLE
Remove logs link to prevent accidental site crash

### DIFF
--- a/src/Template/Element/Header/default.ctp
+++ b/src/Template/Element/Header/default.ctp
@@ -100,10 +100,6 @@
                                'controller' => 'CalendarAdmin',
                                'action' => 'edit'
                            ]) ?></li>
-                           <li><?= $this->Html->link('Logs', [
-                               'controller' => 'Logs',
-                               'action' => 'index'
-                           ]) ?></li>
 			            </ul>
 		            </li>
 		        <?php endif; ?>


### PR DESCRIPTION
Clicking the SuperAdmin -> Logs link in production causes the site to crash.  Remove this link until we decide to display logs in a non-crashy way.