### PR TITLE
[Fix] Handle user not found in AD

### DIFF
--- a/src/Auth/AdAuthenticate.php
+++ b/src/Auth/AdAuthenticate.php
@@ -8,6 +8,7 @@ use Cake\Network\Response;
 use LdapRecord\Models\ActiveDirectory\Entry;
 use LdapRecord\Models\ActiveDirectory\User;
 use LdapRecord\Models\ActiveDirectory\Group;
+use LdapRecord\Models\ModelNotFoundException;
 use LdapRecord\Container;
 use LdapRecord\Connection;
 
@@ -118,7 +119,9 @@ class AdAuthenticate extends FormAuthenticate
             }
 
             return false;
-
+        } catch (ModelNotFoundException $ex) {
+            // Incase we don't find the user in AD
+            return false;
         } catch (Exception $ex) {
             throw new \RuntimeException('Failed to bind to LDAP server. Check Auth configuration settings.');
         }


### PR DESCRIPTION
Bug: if a user enters wrong username then we show a generic error message:
![image](https://user-images.githubusercontent.com/388344/204405584-983af0b7-f168-40b4-a99d-5b1f8b1a2a0a.png)

This commit will handle the ModelNotFoundException exception and show the "Incorrect username or password" error:
![image](https://user-images.githubusercontent.com/388344/204407228-0abaa41a-c0ef-4350-8199-c1533d7601c5.png)

Tested combinations of valid / invalid values for user / pwd.