### PR TITLE
[Fix] Add config to EmailComponent constructor

### DIFF
--- a/src/Controller/Component/EmailComponent.php
+++ b/src/Controller/Component/EmailComponent.php
@@ -13,7 +13,7 @@ class EmailComponent extends Component
     // Execute any other additional setup for your component.
     public function initialize(array $config)
     {
-        parent::initialize();
+        parent::initialize($config);
         $this->_config = $config;
     }
 


### PR DESCRIPTION
added missing $config var in EmailComponent constructor
@skyspook 