### PR TITLE
[Fix] disable submit button on form submission

### DIFF
--- a/webroot/js/app.js
+++ b/webroot/js/app.js
@@ -217,6 +217,16 @@ $(function() {
     // Attach filter to dropdown
     ddElement.insertBefore(textElement, ddElement.firstChild);
   }
+
+  /**
+   * Disable submit button when a form is submitted
+   */
+  $("form").submit(function() {
+    // disable submit button
+    $(":submit", this).attr("disabled", "disabled");
+    // set text to "Working..."
+    $(":submit", this).text("Working...");
+  });
   
 
 });


### PR DESCRIPTION
This PR addresses the cake PHP request black-holed error.

**What causes the black-holed error:** cake PHP includes a single use CSRF token in every form. If the user clicks a submit button twice then the second request will have a token that's no longer valid (since the server invalidates the token when it receives the first request). Cake PHP thinks that the second request is forged and black holes it.

**This fix:** is to disable the submit button when a form is submitted. This PR uses jquery to listen to the submit event on forms and disables the associated submit button and sets the text of the button to "Working...".

**Concerns:** This fix changes all forms in the app. I have tested all the forms I could see. If there is a form that uses ajax to post data then this fix might create issues. I don't see any such forms being used.