### PR TITLE
(bug) allow for `001 - No Tool Reservation Required` to be overused

### DIFF
--- a/config/Seeds/ToolsSeed.php
+++ b/config/Seeds/ToolsSeed.php
@@ -20,7 +20,12 @@ class ToolsSeed extends AbstractSeed
     {
         date_default_timezone_set('UTC');
         $data = [
-            [
+            [ // Run this one first to ensure the ID isn't already taken
+                'id' => 84,
+                'name' => '001 - No Tool Reservation Required',
+                'created' => date('Y-m-d H:i:s'),
+                'modified' => date('Y-m-d H:i:s')
+            ], [
                 'name' => 'Sewing Machine',
                 'created' => date('Y-m-d H:i:s'),
                 'modified' => date('Y-m-d H:i:s')

--- a/src/Model/Table/EventsTable.php
+++ b/src/Model/Table/EventsTable.php
@@ -276,6 +276,10 @@ class EventsTable extends Table
         $validator
             ->add('tools', 'custom', [
                 'rule' => function ($values, $context) {
+                    if (($key = array_search(84, $values['_ids'])) !== false) {
+                        // Janky as it gets. ID 84 is "001 - No Tool Reservation Required"
+                        unset($values['_ids'][$key]);
+                    }
                     if (empty($values['_ids'])) {
                         return true;
                     }


### PR DESCRIPTION
This fixes the 'issue' reported where multiple events can't select the tool `001 - No Tool Reservation Required` (because it is already in use).

For the record, I'm against merging this change in. Please see the conversation in Discord.

Tested locally after creating a tool with the same ID in my local system ([tool id = 84](https://calendar.dallasmakerspace.org/?tool=84)):
![image](https://user-images.githubusercontent.com/242196/223718395-7fb7978e-4ef1-4c0c-9530-1897208a4e04.png)
