### PR TITLE
[DEV-125] Fix special chars in registration title

### DIFF
--- a/src/Template/Registrations/view.ctp
+++ b/src/Template/Registrations/view.ctp
@@ -8,7 +8,7 @@
 
             <?= $this->Flash->render() ?>
 
-            <h2><?= $this->Html->link(h($registration->event->name), [
+            <h2><?= $this->Html->link($registration->event->name, [
                 'controller' => 'Events',
                 'action' => 'view',
                 $registration->event->id


### PR DESCRIPTION
No need to escape the title of the link.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/2a4683c3-b8b2-4284-93b7-c216bbba5e2a) | ![image](https://github.com/user-attachments/assets/b577de4f-01e0-44f5-a463-fca707457b39) |