### PR TITLE
[DEV-126] Registration - check existing email

### DIFF
--- a/src/Controller/RegistrationsController.php
+++ b/src/Controller/RegistrationsController.php
@@ -104,7 +104,16 @@ class RegistrationsController extends AppController
         $this->Crud->on('beforeSave', function (Event $event) {
             $this->Events = TableRegistry::get('Events');
             $registration = $event->getSubject()->entity;
-            if ($registration->type == 'paid') {
+            if ($registration->errors()) {
+                $errors = $registration->errors();
+                // Concatenate all error messages into a single string
+                $errMessage = '';
+                foreach ($errors as $error) {
+                    $errMessage .= implode(' \n', $error);
+                }
+                $this->Flash->error($errMessage);
+                $event->stopPropagation();
+            } elseif ($registration->type == 'paid') {
                 if (!$this->Events->hasPaidSpaces($registration->event_id)) {
                     $this->Flash->error('This event no longer has any paid spaces available. You have not been charged.');
                     $registration->errors('type', ['This event no longer has any paid spaces available.']);

--- a/src/Model/Table/RegistrationsTable.php
+++ b/src/Model/Table/RegistrationsTable.php
@@ -62,14 +62,17 @@ class RegistrationsTable extends Table
             ->requirePresence('name', 'create')
             ->notEmpty('name');
 
-        $validator
-            ->email('email')
+         $validator
+            ->add('email', 'validFormat', [
+                'rule' => 'email',
+                'message' => 'The provided email is not valid.'
+            ])
             ->requirePresence('email', 'create')
             ->notEmpty('email')
             ->add('email', ['unique' => [
                 'rule' => ['validateUnique', ['scope' => 'event_id']],
                 'provider' => 'table',
-                'message' => 'This email address is already associated with a registration for this event.'
+                'message' => 'The email address is already associated with a registration for this event.'
             ]]);
 
         $validator


### PR DESCRIPTION
Check validation for email being used for another registration for the same event.

ToDo: The UX could be better if the form retained the values that the user had just typed in - this can be done seperately.
![image](https://github.com/user-attachments/assets/17351292-8472-4d91-9c18-8ff9c2fcf52d)
