### PR TITLE
[DEV-116] Remove authorization based on Members AD group

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -133,7 +133,6 @@ class AppController extends Controller
         $this->customLog('Viewed ' . $_SERVER[ 'REQUEST_URI' ]);
 
         $isAuthorized = [
-            'canAddEvents' => 0,
             'canManageCategories' => 0,
             'canManageCommittees' => 0,
             'canManageConfigs' => 0,
@@ -151,10 +150,6 @@ class AppController extends Controller
 
         if ($this->Auth->user()) {
             $authorizations = [
-                'Members' => [
-                    'canAddEvents',
-                    'canManageOwnEvents'
-                ],
                 'Calendar Admins' => [
                     'canManageCategories',
                     'canManageCommittees',

--- a/src/Template/Element/Header/default.ctp
+++ b/src/Template/Element/Header/default.ctp
@@ -22,7 +22,7 @@
                     </ul>
                 </li>
                 <?php if (!($this->request->getParam('controller') == 'Events' && $this->request->getParam('action') == 'add')): ?>
-                    <?php if ($canAddEvents): ?>
+                    <?php if ($authUser): ?>
                         <li>
                             <?= $this->Html->link('Submit Event', [
                                 'controller' => 'Events',


### PR DESCRIPTION
The 'Members' AD group hasn't been updated in a while and is no longer in sync with active members.
So we remove references to this group from calendar code. 
Tested manually.