### PR TITLE
fix: Hide checkbox for text messages

### DIFF
--- a/src/Template/Registrations/event.ctp
+++ b/src/Template/Registrations/event.ctp
@@ -41,10 +41,12 @@
                         'default' => ($authUser ? $authUser['mail'] : '')
                     ]) ?>
                     <?= $this->Form->input('phone', [
-                        'default' => ($authUser ? $authUser['telephonenumber'] : '')
+                        'default' => ($authUser ? $authUser['telephonenumber'] : ''),
+                        'help' => 'DMS does not send messages to this number, but the teacher will see it and may reach out in the case of a class delay/etc.'
                     ]) ?>
-                    <?= $this->Form->input('send_text', ['label' => 'Receive text message alerts and updates regarding this event.']) ?>
-
+                    <div style="display: none">
+                        <?= $this->Form->input('send_text', ['label' => 'Receive text message alerts and updates regarding this event.']) ?>
+                    </div>
                     <?php if ($event->advisories): ?>
                         <div class="alert alert-warning">
                             <h4 style="margin-top: 10px"><strong>Special Considerations and Warnings</strong></h4>


### PR DESCRIPTION
DMS does not want to deal with the effort needed for sending SMS at this time, and this checkbox confuses people/gives them a false sense.

It is being hidden, because we might want it back at some point, and I didn't want to make a DB change to set this field non required.