### PR TITLE
feat: Add newJson feed type. Fixes some feed data.

### DIFF
--- a/src/Controller/EventsController.php
+++ b/src/Controller/EventsController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Controller\Component\EmailComponent;
 use App\Model\Entity\Contact;
+use App\Model\Entity\File;
 use LdapRecord\Models\ActiveDirectory\User;
 use LdapRecord\Models\ActiveDirectory\Group;
 use LdapRecord\Container;
@@ -225,8 +226,104 @@ class EventsController extends AppController
         return $this->Crud->execute();
     }
 
+    public function eventsJson()
+    {
+        $this->autoRender = false;
+
+        $today = new Time('America/Chicago');
+        $today->startOfDay()->timezone('UTC');
+        $now = Time::now();
+        $events = $this->Events->find('all')
+            ->select(
+                [
+                    'Events.id',
+                    'Events.event_start',
+                    'Events.event_end',
+                    'Events.name',
+                    'Events.cost',
+                    'Events.room_id',
+                    'Events.short_description',
+                    'Events.long_description',
+                    'Rooms.name',
+                    'Contacts.name',
+                    'Events.modified'
+                ]
+            )
+            ->where(
+                [
+                    'Events.event_start >=' => $today,
+                    'Events.status' => 'approved'
+                ]
+            )
+            ->contain(['Rooms', 'Contacts', 'Categories', 'Files'])
+            ->order(['event_start' => 'ASC']);
+
+
+        $output = [];
+        /** @var \App\Model\Entity\Event $event */
+        foreach ($events as $event) {
+            $initialTotalSpaces = $this->Events->getTotalSpaces($event->id);
+            if ($initialTotalSpaces === true) {
+                $initialTotalSpaces = -1;
+            }
+            $initialFilledSpaces = $this->Events->getFilledSpaces($event->id);
+            if ($initialFilledSpaces === true) {
+                $initialFilledSpaces = -1;
+            }
+
+            $evtObj = [
+                "id" => $event->id,
+                "name" => $event->name,
+                "cost" => "\${$event->cost}.00",
+                "eventStart" => $event->event_start,
+                "eventEnd" => $event->event_end,
+                "room" => $event->room->name,
+                "contact" => $event->contact->name,
+                "shortDescription" => $event->short_description,
+                "longDescription" => $event->long_description,
+                "totalSpaces" => $initialTotalSpaces,
+                "filledSpaces" => $initialFilledSpaces,
+            ];
+
+
+            $imageEndings = ["png", "jpeg", "jpg", "gif", "webp", "svg"];
+
+            /** @var File $file */
+            foreach ($event->files as $file) {
+                if ($file->private) {
+                    continue;
+                }
+
+                $exploded = explode(".", $file->file);
+                $imageEnding = ($exploded !== false && count($exploded) >= 2) ? $exploded[count($exploded) - 1] : '';
+                $filePayload = [
+                    "url" => Configure::read('App.fullBaseUrl') . '/' . str_replace("webroot/", "", $file->dir) . rawurlencode($file->file),
+                    "type" => $file->type,
+                    "length" => filesize(ROOT . DS . $file->dir . $file->file),
+                ];
+                if (in_array($imageEnding, $imageEndings)) {
+                    $evtObj["images"][] = $filePayload;
+                } else {
+                    $evtObj["files"][] = $filePayload;
+                }
+            }
+
+            $output[] = (object)$evtObj;
+        }
+
+        return json_encode($output, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    }
+
     public function feed($feedtype = "vcal")
     {
+        if ($feedtype === "newJson") {
+            $this->response = $this->response
+                ->withStringBody($this->eventsJson())
+                ->withType('application/json')
+                ->withAddedHeader("Access-Control-Allow-Origin", "*");
+            return $this->response;
+        }
+
         // TODO: Accept arguments like calendar view and include location
         $this->autoRender = false;
 
@@ -255,7 +352,7 @@ class EventsController extends AppController
                 'Events.status' => 'approved'
                 ]
             )
-            ->contain(['Rooms', 'Contacts', 'Categories'])
+            ->contain(['Rooms', 'Contacts', 'Categories', 'Files'])
             ->order(['event_start' => 'ASC']);
 
         // This allows us to use the applyQueryFilters method for the feed
@@ -337,10 +434,10 @@ class EventsController extends AppController
             // Set the feed channel elements
 
             $feed->setTitle('Dallas Makerspace Calendar' . $title_addon);
-            $feed->setLink(Router::url('/', true));
-            $feed->setDescription('Events and Classes avaliable at the Dallas Makerspace' . $description_addon);
+            $feed->setDescription('Events and Classes available at the Dallas Makerspace' . $description_addon);
 
             // add each event/class in feed
+            /** @var \App\Model\Entity\Event $event */
             foreach ($events as $event) {
                 $view = new View($this->request);
                 $view->set('event', $event);
@@ -356,10 +453,34 @@ class EventsController extends AppController
                 $feed_event->setPublicId($url, false);
 
                 $feed_author = $feed_event->newAuthor();
-                $feed_author->getName($event->contact->name);
+                $feed_author->setName($event->contact->name);
                 $feed_author->setUri("");
                 $feed_author->setEmail("");
                 $feed_event->setAuthor($feed_author);
+
+
+//                $feed_media = $feed_event->newMedia();
+
+                $imageEndings = ["png", "jpeg", "jpg", "gif", "webp", "svg"];
+
+                /** @var File $file */
+                foreach ($event->files as $file) {
+                    if ($file->private) {
+                        continue;
+                    }
+
+                    $exploded = explode(".", $file->file);
+                    $imageEnding = ($exploded !== false && count($exploded) >= 2) ? $exploded[count($exploded) - 1] : '';
+                    if (in_array($imageEnding, $imageEndings)) {
+                        $media = $feed_event->newMedia();
+                        $media->setUrl(Configure::read('App.fullBaseUrl') . '/' . str_replace("webroot/", "", $file->dir) . rawurlencode($file->file));
+                        $media->setType($file->type);
+                        $media->setLength(filesize(ROOT . DS . $file->dir . $file->file));
+                        $feed_event->addMedia($media);
+                    }
+                }
+
+                //  str_replace("webroot/", "", $image->dir) . $image->file
 
                 foreach ($event->categories as $category) {
                     $feed_category = $feed_event->newCategory();
@@ -375,21 +496,33 @@ class EventsController extends AppController
             $feedIo = Factory::create()->getFeedIo();
 
             if ($feedtype === "atom") {
+                $feed->setPublicId(Router::url(['controller' => 'events', 'action' => 'feed/atom', '_ssl' => true,]));
+                $feed->setLink(Router::url(['controller' => 'events', 'action' => 'feed/atom', '_ssl' => true,]));
+
                 $this->response = $this->response
                     ->withStringBody($feedIo->format($feed, 'atom'))
-                    ->withType('application/atom+xml');
+                    ->withType('text/xml');
             } elseif ($feedtype === "json") {
+                $feed->setPublicId(Router::url(['controller' => 'events', 'action' => 'feed/json', '_ssl' => true,]));
+                $feed->setLink(Router::url(['controller' => 'events', 'action' => 'feed/json', '_ssl' => true,]));
+
                 $this->response = $this->response
                     ->withStringBody($feedIo->format($feed, 'json'))
                     ->withType('application/json');
             } elseif ($feedtype === "rss") {
+                $feed->setPublicId(Router::url(['controller' => 'events', 'action' => 'feed/rss', '_ssl' => true,]));
+                $feed->setLink(Router::url(['controller' => 'events', 'action' => 'feed/rss', '_ssl' => true,]));
+
                 $this->response = $this->response
                     ->withStringBody($feedIo->format($feed, 'rss'))
-                    ->withType('application/rss+xml');
+                    ->withType('text/xml');
             } else { // Default to RSS
+                $feed->setPublicId(Router::url(['controller' => 'events', 'action' => 'feed/rss', '_ssl' => true,]));
+                $feed->setLink(Router::url(['controller' => 'events', 'action' => 'feed/rss', '_ssl' => true,]));
+
                 $this->response = $this->response
                     ->withStringBody($feedIo->format($feed, 'rss'))
-                    ->withType('application/rss+xml');
+                    ->withType('text/xml');
             }
         }
 

--- a/src/Model/Entity/File.php
+++ b/src/Model/Entity/File.php
@@ -7,6 +7,7 @@ use Cake\ORM\Entity;
  * File Entity.
  *
  * @property int $id
+ * @property boolean $private
  * @property string $file
  * @property string $dir
  * @property string $type

--- a/src/Template/Events/feed_contents.ctp
+++ b/src/Template/Events/feed_contents.ctp
@@ -3,7 +3,8 @@
                                     <td><strong>When</strong></td>
                                     <td>
                                     <?php
-                                            $startdate = $this->Time->fromString($event->event_start, 'America/Chicago')->format('Ymd');
+                                    /** @var \App\Model\Entity\Event $event */
+                                    $startdate = $this->Time->fromString($event->event_start, 'America/Chicago')->format('Ymd');
                                             $enddate = $this->Time->fromString($event->event_end, 'America/Chicago')->format('Ymd');
                                             if ($startdate == $enddate) {
                                                 $secondFormat = "h:mma";
@@ -54,17 +55,7 @@
                                     <td><strong>Cost</strong></td>
                                     <td>$<?= number_format($event->cost, 2) ?></td>
                                 </tr>
-                                <tr>
-                                    <td></td>
-                                    <td>
-                                        <?= str_replace('"', "'", $this->Html->link('More Info and RSVP »', [
-                                            'action' => 'view',
-                                            $event->id
-                                        ])) ?>
-                                    </td>
-                                </tr>
                             </table>
                             <p>
 								<?= nl2br(h($event->long_description)) ?>
 							</p>
-							


### PR DESCRIPTION
This should also have the side effect of clearing up some of the prod only changes that hadn't been committed and needed to be stash/pop every deployment. (This does not fix all them yet).

Summary of changes:
- Changed the Content-Type to the more accepted text/xml where neccessary
- Updated the correct link/url paths for the feeds. 
- Added newJson feed type, which is an actual JSON payload, instead of the feed encoded as JSON
- Add references to images and/or files to a couple of the feeds.