### PR TITLE
Increase session timeout to 60 days

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -322,6 +322,7 @@ return [
      */
     'Session' => [
         'defaults' => 'php',
+        'timeout' => 86400, // 60 days in minutes
     ],
 
     /**


### PR DESCRIPTION
## Summary
- Increases session timeout from PHP default (24 minutes) to 60 days
- Reduces need for frequent re-authentication
- Matches the session timeout used on Discourse (Talk)

## Test plan
Verified locally