### PR TITLE
Comment out ATOM feeds functionality (INFRA-316)

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -322,6 +322,7 @@ return [
      */
     'Session' => [
         'defaults' => 'php',
+        'timeout' => 86400, // 60 days in minutes
     ],
 
     /**

--- a/src/Controller/EventsController.php
+++ b/src/Controller/EventsController.php
@@ -509,15 +509,6 @@ class EventsController extends AppController
 
             $feedIo = Factory::create()->getFeedIo();
 
-            // ATOM feed commented out due to memory leak issues (INFRA-347)
-            // if ($feedtype === "atom") {
-            //     $feed->setPublicId(Router::url(['controller' => 'events', 'action' => 'feed/atom', '_ssl' => true,]));
-            //     $feed->setLink(Router::url(['controller' => 'events', 'action' => 'feed/atom', '_ssl' => true,]));
-
-            //     $this->response = $this->response
-            //         ->withStringBody($feedIo->format($feed, 'atom'))
-            //         ->withType('text/xml');
-            // } else
             if ($feedtype === "json") {
                 $feed->setPublicId(Router::url(['controller' => 'events', 'action' => 'feed/json', '_ssl' => true,]));
                 $feed->setLink(Router::url(['controller' => 'events', 'action' => 'feed/json', '_ssl' => true,]));

--- a/src/Controller/EventsController.php
+++ b/src/Controller/EventsController.php
@@ -509,14 +509,16 @@ class EventsController extends AppController
 
             $feedIo = Factory::create()->getFeedIo();
 
-            if ($feedtype === "atom") {
-                $feed->setPublicId(Router::url(['controller' => 'events', 'action' => 'feed/atom', '_ssl' => true,]));
-                $feed->setLink(Router::url(['controller' => 'events', 'action' => 'feed/atom', '_ssl' => true,]));
+            // ATOM feed commented out due to memory leak issues (INFRA-347)
+            // if ($feedtype === "atom") {
+            //     $feed->setPublicId(Router::url(['controller' => 'events', 'action' => 'feed/atom', '_ssl' => true,]));
+            //     $feed->setLink(Router::url(['controller' => 'events', 'action' => 'feed/atom', '_ssl' => true,]));
 
-                $this->response = $this->response
-                    ->withStringBody($feedIo->format($feed, 'atom'))
-                    ->withType('text/xml');
-            } elseif ($feedtype === "json") {
+            //     $this->response = $this->response
+            //         ->withStringBody($feedIo->format($feed, 'atom'))
+            //         ->withType('text/xml');
+            // } else
+            if ($feedtype === "json") {
                 $feed->setPublicId(Router::url(['controller' => 'events', 'action' => 'feed/json', '_ssl' => true,]));
                 $feed->setLink(Router::url(['controller' => 'events', 'action' => 'feed/json', '_ssl' => true,]));
 


### PR DESCRIPTION
## Summary
- Comment out ATOM feed generation code in EventsController to address memory leak issues
- ATOM feed requests will now fall through to default RSS behavior
- Related to INFRA-316: https://tasks.dallasmakerspace.org/browse/INFRA-316

## Test plan
✅ Verify that `/events/feed/rss` still works correctly
✅ Verify that `/events/feed/json` still works correctly
✅ Confirm that `/events/feed/atom` now returns RSS format instead of ATOM