### PR TITLE
Add devcontainer configuration for VS Code development environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+  "name": "DMS Calendar",
+  "dockerComposeFile": ["../docker-compose.yml", "docker-compose.devcontainer.yml"],
+  "service": "app",
+  "workspaceFolder": "/var/www",
+  "shutdownAction": "stopCompose",
+  "forwardPorts": [8000, 8025, 8081, 8899],
+  "portsAttributes": {
+    "8000": { "label": "App" },
+    "8025": { "label": "MailHog" },
+    "8081": { "label": "phpMyAdmin" },
+    "8899": { "label": "Traefik Dashboard" }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "bmewburn.vscode-intelephense-client",
+        "xdebug.php-debug",
+        "EditorTeam.PhpCS",
+        "recca0120.vscode-phpunit"
+      ],
+      "settings": {
+        "php.validate.executablePath": "/usr/local/bin/php",
+        "php.executablePath": "/usr/local/bin/php",
+        "intelephense.environment.phpVersion": "7.4.0",
+        "[php]": {
+          "editor.defaultFormatter": "bmewburn.vscode-intelephense-client"
+        }
+      }
+    }
+  },
+  "postCreateCommand": "bash /var/www/.devcontainer/post-create.sh"
+}

--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -1,0 +1,8 @@
+services:
+  app:
+    # Override entrypoint/command so the container stays running for devcontainer attach
+    # The startup script (composer install, migrations, apache) is handled by post-create instead
+    entrypoint: ["/bin/sh", "-c", "while sleep 1000; do :; done"]
+    command: []
+    environment:
+      COMPOSER_HOME: /var/www/.composer

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -e
+
+# Symlink webroot as Apache document root
+rm -rf /var/www/html
+ln -sf /var/www/webroot /var/www/html
+
+# Copy php.ini and xdebug config
+cp /var/www/.docker/php-dev.ini $PHP_INI_DIR/php.ini
+cp /var/www/.docker/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
+
+# Set up log files
+mkdir -p /var/www/logs
+touch /var/log/xdebug.log /var/www/logs/queries.log
+chmod 666 /var/log/xdebug.log /var/www/logs/queries.log
+mkdir -p /var/log/apache2
+chmod 777 /var/log/apache2 /var/log
+
+# Link app config
+[ -f /var/www/config/app.php ] || ln -sf /var/www/config/app.default.php /var/www/config/app.php
+
+# Install PHP dependencies
+cd /var/www
+php /opt/composer/composer.phar install
+
+# Wait for DB and run migrations
+/var/www/.docker/wait-for-it.sh "${DB_HOST:-db}:3306" -s -t 60 -- \
+  php /var/www/bin/cake.php migrations migrate
+
+# Seed if empty
+result=$(mysql -N -h "${DB_HOST:-db}" -u "${DB_USERNAME:-calendar}" -p"${DB_PASSWORD:-calendar}" "${DB_DATABASE:-dms-calendar}" -s -e "select count(*) from categories;" 2>/dev/null || echo 0)
+if [ "$result" -eq 0 ]; then
+  php /var/www/bin/cake.php migrations seed
+fi
+
+# Start Apache in foreground via supervisord / background
+source /etc/apache2/envvars
+apache2 -D FOREGROUND &
+
+echo "Dev environment ready. App running on port 80."

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 config/Migrations/schema-dump-default.lock
 /html
 .vscode/settings.json
+.devcontainer/.onCreateCommandMarker
+.devcontainer/.postCreateCommandMarker
+.devcontainer/.updateContentCommandMarker


### PR DESCRIPTION
This adds the ability to use an online IDE or quick VSCode initialization to get a development environment in 1 click rather than manually provisioning one.