### PR TITLE
Hide chrome and improve clock layout in kiosk mode

### DIFF
--- a/src/Template/Events/index.ctp
+++ b/src/Template/Events/index.ctp
@@ -17,6 +17,7 @@ $this->Html->meta(
 ?>
 <div class="events index">
     <?= $this->Flash->render() ?>
+    <?php if (!$this->request->getQuery('kiosk')): ?>
     <div class="text-right">
         <?= $this->Html->link('<i class="fa fa-calendar" aria-hidden="true"></i> Calendar View', [
             'action' => 'calendar'
@@ -36,6 +37,7 @@ $this->Html->meta(
         &nbsp;
     </div>
     <br>
+    <?php endif; ?>
     <div class="page-header">
         <div class="row">
             <div class="col-sm-7">

--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -25,10 +25,17 @@
     echo $this->fetch('css');
     ?>
 </head>
-<body<?= $this->request->getParam('action') == 'embed' ? ' class="embed"' : '' ?>>
+<?php $isKiosk = (bool)$this->request->getQuery('kiosk'); ?>
+<body<?php
+    if ($this->request->getParam('action') == 'embed') {
+        echo ' class="embed"';
+    } elseif ($isKiosk) {
+        echo ' class="kiosk"';
+    }
+?>>
 
 <?php
-if ($this->request->getParam('action') != 'embed') {
+if ($this->request->getParam('action') != 'embed' && !$isKiosk) {
     echo $this->element('Header/default');
 }
 ?>
@@ -38,7 +45,7 @@ if ($this->request->getParam('action') != 'embed') {
 </div>
 
 <?php
-if ($this->request->getParam('action') != 'embed') {
+if ($this->request->getParam('action') != 'embed' && !$isKiosk) {
     echo $this->element('Footer/default');
 }
 

--- a/webroot/css/app.css
+++ b/webroot/css/app.css
@@ -12,6 +12,10 @@ body.embed {
   margin: 0;
 }
 
+body.kiosk {
+  margin-top: 0;
+}
+
 body.embed .page-header {
   margin-top: 0;
 }

--- a/webroot/js/kiosk.js
+++ b/webroot/js/kiosk.js
@@ -15,7 +15,7 @@ var kiosk = GetURLParameter('kiosk');
 if (kiosk) {
     const options = { weekday: 'short', month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric', second: 'numeric'};
 
-    $("div.container div.events.index").prepend("<div id='kiosk-clock' style='float: left;font-size: 30px;'></div>");
+    $("div.container div.events.index").prepend("<div id='kiosk-clock' style='font-size: 30px; padding-top: 20px;'></div>");
 
     jQuery(function($) {
         setInterval(function() {


### PR DESCRIPTION
Hide the top navbar, footer, and Calendar View/RSS links when the kiosk query parameter is present. Zero the body top margin so the content doesn't sit in empty space where the fixed navbar used to be. Make the kiosk clock a block element with top padding so the "Upcoming Classes and Events" heading sits on its own line below it.

This is how it looks in the new kiosk mode.
<img width="533" height="782" alt="image" src="https://github.com/user-attachments/assets/496c981a-334d-46e0-83b3-18684a8019a4" />
