### PR TITLE
Fix misleading "CSRF token mismatch" on event-form file uploads

### DIFF
--- a/.docker/php-dev.ini
+++ b/.docker/php-dev.ini
@@ -28,13 +28,13 @@ request_order = "GP"
 register_argc_argv = Off
 auto_globals_jit = On
 
-post_max_size = 8M
+post_max_size = 41M
 default_mimetype = "text/html"
 default_charset = "UTF-8"
 
 enable_dl = Off
 file_uploads = On
-upload_max_filesize = 2M
+upload_max_filesize = 8M
 max_file_uploads = 20
 
 allow_url_fopen = On

--- a/.docker/prod/php-production.ini
+++ b/.docker/prod/php-production.ini
@@ -32,7 +32,7 @@ variables_order = "GPCS"
 request_order = "GP"
 register_argc_argv = Off
 auto_globals_jit = On
-post_max_size = 8M
+post_max_size = 41M
 auto_prepend_file =
 auto_append_file =
 
@@ -43,7 +43,7 @@ user_dir =
 enable_dl = Off
 
 file_uploads = On
-upload_max_filesize = 10M
+upload_max_filesize = 8M
 max_file_uploads = 20
 allow_url_fopen = On
 allow_url_include = Off

--- a/src/Application.php
+++ b/src/Application.php
@@ -14,6 +14,7 @@
  */
 namespace App;
 
+use App\Middleware\RequestEntityTooLargeMiddleware;
 use Cake\Core\Configure;
 use Cake\Core\Exception\MissingPluginException;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
@@ -82,6 +83,10 @@ class Application extends BaseApplication
             // pass null as cacheConfig, example: `new RoutingMiddleware($this)`
             // you might want to disable this cache in case your routing is extremely simple
             ->add(new RoutingMiddleware($this, '_cake_routes_'))
+
+            // Reject over-sized requests with a clear 413 before the CSRF
+            // middleware mistakes the truncated body for a token mismatch.
+            ->add(new RequestEntityTooLargeMiddleware())
 
             // Add csrf middleware.
             ->add(new CsrfProtectionMiddleware([

--- a/src/Middleware/RequestEntityTooLargeMiddleware.php
+++ b/src/Middleware/RequestEntityTooLargeMiddleware.php
@@ -1,0 +1,66 @@
+<?php
+namespace App\Middleware;
+
+use Cake\Http\Exception\HttpException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UploadedFileInterface;
+
+/**
+ * Rejects requests that PHP couldn't fully parse for size reasons, so the
+ * controller (and the user) never see a half-saved state or a misleading
+ * "CSRF token mismatch."
+ *
+ *  - Total body over post_max_size: PHP drops $_POST and $_FILES entirely.
+ *    Detected from the still-intact Content-Length header.
+ *  - A single file over upload_max_filesize: PHP marks that file with
+ *    UPLOAD_ERR_INI_SIZE and lets the rest of the request through.
+ *    Detected by walking the parsed uploaded files.
+ */
+class RequestEntityTooLargeMiddleware
+{
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, $next)
+    {
+        if (!in_array($request->getMethod(), ['POST', 'PUT', 'PATCH'], true)) {
+            return $next($request, $response);
+        }
+
+        $contentLength = (int)$request->getHeaderLine('Content-Length');
+        $postMaxBytes  = (int)ini_get('post_max_size') * 1048576;
+
+        if ($postMaxBytes > 0 && $contentLength > $postMaxBytes) {
+            $sentMb = round($contentLength / 1048576, 1);
+            throw new HttpException(
+                sprintf(
+                    'Upload too large: your request was about %s MB, but the server limit is %d MB total per submission. '
+                    . 'Reduce the total size of your attachments and try again.',
+                    $sentMb,
+                    $postMaxBytes / 1048576
+                ),
+                413
+            );
+        }
+
+        $uploadedFiles = $request->getUploadedFiles();
+        $tooLarge      = [];
+        array_walk_recursive($uploadedFiles, function ($file) use (&$tooLarge) {
+            if ($file instanceof UploadedFileInterface && $file->getError() === UPLOAD_ERR_INI_SIZE) {
+                $tooLarge[] = $file->getClientFilename() ?: '(unnamed file)';
+            }
+        });
+
+        if (!empty($tooLarge)) {
+            $perFileMb = (int)ini_get('upload_max_filesize');
+            throw new HttpException(
+                sprintf(
+                    'File too large: %s exceeds the per-file limit of %d MB. Reduce the file size and try again.',
+                    implode(', ', $tooLarge),
+                    $perFileMb
+                ),
+                413
+            );
+        }
+
+        return $next($request, $response);
+    }
+}

--- a/src/Template/Error/error400.ctp
+++ b/src/Template/Error/error400.ctp
@@ -38,9 +38,11 @@ if (Configure::read('debug')) {
 }
 ?>
 <h1><?= h($message) ?></h1>
-<h4>
-    <?= sprintf(__d('cake', 'The requested address \'%s\' was not found on this server.'), "<strong style='user-select: all!important'>$url</strong>") ?>
-</h4>
+<?php if (isset($error) && method_exists($error, 'getCode') && $error->getCode() === 404): ?>
+    <h4>
+        <?= sprintf(__d('cake', 'The requested address \'%s\' was not found on this server.'), "<strong style='user-select: all!important'>$url</strong>") ?>
+    </h4>
+<?php endif; ?>
 <br>
 <hr>
 <br>


### PR DESCRIPTION
Users hitting /events/add with a PowerPoint or Word attachment were consistently met with a "CSRF token mismatch" page, every browser, every machine, every day. This change fixes the misdetection, raises the size ceiling to a usable level, and turns size-related rejections into clear 413 responses with actionable messages.

== Original problems

1. Misleading "CSRF token mismatch" 403. PHP-FPM's post_max_size was 8M (.docker/php-dev.ini, .docker/prod/ php-production.ini). Whenever the multipart POST body exceeded that limit, PHP discards $_POST and $_FILES *before any application code runs*, while leaving the csrfToken cookie intact. CsrfProtection- Middleware then compared the cookie against an empty form field and threw InvalidCsrfTokenException — the exact 403 users saw, even though nothing was actually wrong with their CSRF token. Office documents routinely exceed 8 MB, so this fired on the happy path.

2. Per-file limit larger than total limit (prod). prod ini had upload_max_filesize = 10M with post_max_size = 8M. The per-file cap was effectively dead code — post_max_size always trips first — and it suggested a 10 MB ceiling that was never actually honored.

3. Error400 template lied for non-404 errors. src/Template/Error/error400.ctp printed "The requested address '%s' was not found on this server." as the sub-heading for *every* 4xx error. That copy is only correct for 404. On the CSRF 403 it told users the URL didn't exist (it did), compounding the confusion.

4. Per-file PHP rejections aren't request-level. When PHP's upload_max_filesize is exceeded by a single file, PHP does NOT reject the request. It marks just that file with UPLOAD_ERR_INI_SIZE and lets the rest of the body through. CSRF passes, the controller runs, and the file silently fails to attach — another source of "the form just doesn't work" complaints.

== Solutions

* Raise post_max_size to 41M and upload_max_filesize to 8M (dev + prod). Reasoning under "Sizing".
* Add App\Middleware\RequestEntityTooLargeMiddleware, registered before CsrfProtectionMiddleware in src/Application.php. It:
    - Compares Content-Length against post_max_size and throws HttpException(413) when the body would be discarded. This catches the original bug at the source, before CSRF can misinterpret it.
    - Walks $request->getUploadedFiles() and throws HttpException(413) when any file is flagged UPLOAD_ERR_INI_SIZE, naming the offender. This catches the per-file case described in problem (4) so nothing half-saves.
* Gate the "address not found on this server" sub-heading in src/Template/Error/error400.ctp behind code === 404, so 413 (and any other non-404 4xx) shows the actual message instead of nonsense.

== Sizing

The event add/edit form has 5 hard-coded file slots (src/Template/Events/add.ctp:64, edit.ctp:83). There is no JS to add more, and edit shares the same 5-slot cap (existing files occupy slots). So a single submission carries at most 5 new files.

* Per-file cap: 8M. Before this change, post_max_size = 8M was the effective per-file ceiling — anything larger broke the whole form. Holding per-file at 8M keeps that practical limit unchanged for users while no longer doing it via the wrong directive.

* Total cap: 41M = 5 * 8M + ~1M envelope (form fields, multipart boundaries, CSRF token, etc.). The reason for raising the *total* rather than keeping it at 8M: even if a user is blocked from attaching 5 * 8M at create time, they could previously do it across multiple edit submissions (upload some, save, edit again, upload more). The total cap needs to accommodate what the UI can submit in a single request — five 8 MB files — or the same bug returns the moment the upload form is fully populated.

== Verification

Reproduced against the project's docker-compose stack (app + db). Four scenarios, all clean exits:

  | Request                                | Result | Message                        |
  |----------------------------------------|--------|--------------------------------|
  | 7 MB single file (within all caps)     | 302    | (passes middleware)            |
  | 10 MB single file (per-file 8M)        | 413    | "File too large: NAME ..."     |
  | 42 MB body (post_max_size 41M)         | 413    | "Upload too large: ... 41 MB"  |
  | Mix: 7 MB + 10 MB file                 | 413    | "File too large: oversize.pptx"|

Real 404s still render the "not found on this server" sub-heading; 413s (and other non-404 4xx) no longer do.