### PR TITLE
Fix test datasource configuration and add GitHub Actions CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,65 @@
+name: Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  phpunit:
+    runs-on: ubuntu-latest
+
+    services:
+      mariadb:
+        image: mariadb:10.11
+        env:
+          MARIADB_ROOT_PASSWORD: root
+          MARIADB_DATABASE: dms-calendar
+          MARIADB_USER: calendar
+          MARIADB_PASSWORD: calendar
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
+
+    env:
+      DB_HOST: 127.0.0.1
+      DB_USERNAME: calendar
+      DB_PASSWORD: calendar
+      DB_DATABASE: dms-calendar
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          extensions: mbstring, intl, pdo_mysql
+          tools: composer:v2
+          coverage: none
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php74-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-php74-
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Configure application
+        run: ln -s app.default.php config/app.php
+
+      - name: Create test database
+        run: |
+          mysql -h 127.0.0.1 -uroot -proot -e "CREATE DATABASE \`dms-calendar-test\`;"
+          mysql -h 127.0.0.1 -uroot -proot -e "GRANT ALL PRIVILEGES ON \`dms-calendar-test\`.* TO 'calendar'@'%';"
+          mysql -h 127.0.0.1 -uroot -proot -e "FLUSH PRIVILEGES;"
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit --no-coverage

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,3 +45,21 @@ More details on the rest can be found at [CakePHP](https://book.cakephp.org/) - 
 
 **Warning:** check [composer.json](../composer.json) to ensure you're looking at docs for the right version of CakePHP.
 
+
+## Tests
+
+Tests live alongside the code in [src/](../src/), not under `tests/TestCase/`. [phpunit.xml.dist](../phpunit.xml.dist) is configured to discover anything matching `*Test.php` in `./src`. Run the suite under Docker:
+
+```
+docker compose exec -w /var/www app vendor/bin/phpunit --no-coverage
+```
+
+### Test datasource
+
+[tests/bootstrap.php](../tests/bootstrap.php) registers a dedicated `test` connection by reading the `default` config from [config/app.default.php](../config/app.default.php) and appending `-test` to the database name. Fixtures `TRUNCATE` the tables they manage, so the suite is careful never to run against your dev database — only against the derived `<dbname>-test` schema on the same host.
+
+**Production guardrail:** the bootstrap refuses to start if the resolved `default` host isn't on a small allowlist (`localhost`, `127.0.0.1`, `::1`, `db` — the docker-compose service name in [docker-compose.yml](../docker-compose.yml)). This stops `vendor/bin/phpunit` from doing any damage if `DB_HOST` is misconfigured to point at the prod RDS instance. If you legitimately need to run tests against another host, edit the allowlist in `tests/bootstrap.php`.
+
+### CI
+
+[.github/workflows/test.yml](../.github/workflows/test.yml) runs the full PHPUnit suite on every push and pull request against a MariaDB 10.11 service container. CI uses `DB_HOST=127.0.0.1`, which is on the allowlist above.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,7 +14,7 @@
     <!-- Add any additional test suites you want to run here -->
     <testsuites>
         <testsuite name="App Test Suite">
-            <directory>./tests/TestCase</directory>
+            <directory suffix="Test.php">./src</directory>
         </testsuite>
         <!-- Add plugin test suites here. -->
     </testsuites>

--- a/src/Controller/CommitteesControllerTest.php
+++ b/src/Controller/CommitteesControllerTest.php
@@ -17,7 +17,7 @@ class CommitteesControllerTest extends IntegrationTestCase
      */
     public $fixtures = [
 		'app.committees',
-		'app.honorarias'
+		'app.honoraria'
 	];
 
     /**

--- a/src/Controller/ContactsControllerTest.php
+++ b/src/Controller/ContactsControllerTest.php
@@ -19,7 +19,7 @@ class ContactsControllerTest extends IntegrationTestCase
 		'app.contacts',
 		'app.w9s',
 		'app.events',
-		'app.honorarias'
+		'app.honoraria'
 	];
 
     /**

--- a/src/Controller/EventsControllerTest.php
+++ b/src/Controller/EventsControllerTest.php
@@ -20,7 +20,7 @@ class EventsControllerTest extends IntegrationTestCase
 		'app.rooms',
 		'app.contacts',
 		'app.prerequisites',
-		'app.honorarias',
+		'app.honoraria',
 		'app.categories',
 		'app.tools',
 		'app.files',

--- a/src/Controller/HonorariaControllerTest.php
+++ b/src/Controller/HonorariaControllerTest.php
@@ -16,7 +16,7 @@ class HonorariaControllerTest extends IntegrationTestCase
      * @var array
      */
     public $fixtures = [
-		'app.honorarias',
+		'app.honoraria',
 		'app.events',
 		'app.committees'
 	];

--- a/src/Model/Table/EventsTableTest.php
+++ b/src/Model/Table/EventsTableTest.php
@@ -28,7 +28,7 @@ class EventsTableTest extends TestCase
 		'app.rooms',
 		'app.contacts',
 		'app.prerequisites',
-		'app.honorarias',
+		'app.honoraria',
 		'app.categories',
 		'app.tools',
 		'app.files',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,3 +10,10 @@ require dirname(__DIR__) . '/vendor/autoload.php';
 require dirname(__DIR__) . '/config/bootstrap.php';
 
 $_SERVER['PHP_SELF'] = '/';
+
+// Register a dedicated 'test' datasource that mirrors the default
+// connection but points at a separate database. Fixtures truncate
+// tables, so we never want them touching the dev database.
+$defaultConfig = \Cake\Datasource\ConnectionManager::getConfig('default');
+$defaultConfig['database'] = ($defaultConfig['database'] ?? 'dms-calendar') . '-test';
+\Cake\Datasource\ConnectionManager::setConfig('test', $defaultConfig);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,5 +15,18 @@ $_SERVER['PHP_SELF'] = '/';
 // connection but points at a separate database. Fixtures truncate
 // tables, so we never want them touching the dev database.
 $defaultConfig = \Cake\Datasource\ConnectionManager::getConfig('default');
+
+// Guardrail: refuse to run tests against any non-local DB host. Fixtures
+// TRUNCATE tables, so a misconfigured DATABASE_URL pointing at prod could
+// wipe a 'dms-calendar-test' schema living on the prod RDS instance.
+$host = $defaultConfig['host'] ?? 'localhost';
+$allowedHosts = ['localhost', '127.0.0.1', '::1', 'db'];
+if (!in_array($host, $allowedHosts, true)) {
+    fwrite(STDERR, "REFUSING to run tests: 'default' connection host '{$host}' "
+        . "is not in the local allowlist (" . implode(', ', $allowedHosts) . ").\n"
+        . "If this is intentional, edit tests/bootstrap.php.\n");
+    exit(1);
+}
+
 $defaultConfig['database'] = ($defaultConfig['database'] ?? 'dms-calendar') . '-test';
 \Cake\Datasource\ConnectionManager::setConfig('test', $defaultConfig);


### PR DESCRIPTION
## Summary

Five things in this PR:

1. **Fix `tests/bootstrap.php` so the test runner can actually load fixtures.** The previous bootstrap aliased `test → default`, but CakePHP's `FixtureManager::_aliasConnections()` unconditionally calls `alias('test', 'default')` (the inverse direction) at line 124, overriding the bootstrap alias. After fixtures initialise, both names resolve to a `test` config that was never set up, so any test that touches a Table fails with:

   ```
   Cake\Datasource\Exception\MissingDatasourceConfigException: The datasource configuration "test" was not found.
   ```

   Replaced the alias with a real `test` Datasource registration that clones the default connection config and swaps the database name. Fixtures truncate tables, so they get a dedicated `dms-calendar-test` schema rather than touching dev data.

2. **Make the PHPUnit suite actually discoverable.** Two small things were preventing the suite from running:
   - `phpunit.xml.dist` pointed at `./tests/TestCase`, which is empty — every test file in this repo lives under `src/`. Repointed the testsuite at `./src` with a `suffix="Test.php"` glob, which picks up all 19 test classes.
   - Five test classes referenced a typo'd fixture, `app.honorarias` (the actual fixture class is `HonorariaFixture`, singular). That caused fixture init to throw and aborted those classes' runs. Renamed them to `app.honoraria` in `CommitteesControllerTest`, `ContactsControllerTest`, `EventsControllerTest`, `HonorariaControllerTest`, and `EventsTableTest`.

3. **Add a GitHub Actions workflow** (`.github/workflows/test.yml`) that spins up MariaDB 10.11 as a service container, installs PHP 7.4 + Composer deps, symlinks `config/app.php` to the default config (matching what the docker startup does), creates the test database, and runs the full PHPUnit suite on every push to `master` and on every PR.

4. **Refuse to run tests against a non-local DB host.** Per review feedback: if a developer's `DATABASE_URL` is misconfigured to point at the prod RDS instance, the bootstrap would derive `dms-calendar-test` from it and `FixtureManager` would happily `TRUNCATE` every table it manages against the prod host. The bootstrap now exits 1 with a clear error if the resolved `default` host isn't on a small allowlist (`localhost`, `127.0.0.1`, `::1`, `db` — the docker-compose service name). CI uses `DB_HOST=127.0.0.1`, which is covered. If a future use case legitimately needs another host, the allowlist is one line in `tests/bootstrap.php`.

5. **Document the whole thing** in `docs/README.md` (new `## Tests` section): where tests live, the `docker compose exec` command to run them, how the `test` datasource is derived from `default`, the production guardrail, and a pointer to the CI workflow.

## Setup note for local devs

After this PR, running tests locally requires the test database to exist on the same MariaDB server (CI handles this automatically):

```sql
CREATE DATABASE `dms-calendar-test`;
GRANT ALL PRIVILEGES ON `dms-calendar-test`.* TO 'calendar'@'%';
FLUSH PRIVILEGES;
```

Fixtures auto-create their own tables from each fixture's `$fields` definition, so no schema import is required.

## What CI runs

The full suite — 100 test methods across all 19 test classes. Today most of them are still master's `markTestIncomplete` skeletons, but each class's `setUp()` exercises fixture init against the new `test` datasource, so any future regression in bootstrap/fixture wiring would fail CI immediately. Branches that add real tests on top of this inherit CI without any further setup.
